### PR TITLE
Fix typo - Zoom.js docs refers to shake effect

### DIFF
--- a/src/cameras/2d/effects/Zoom.js
+++ b/src/cameras/2d/effects/Zoom.js
@@ -167,7 +167,7 @@ var Zoom = new Class({
      * @param {number} zoom - The target Camera zoom value.
      * @param {integer} [duration=1000] - The duration of the effect in milliseconds.
      * @param {(string|function)} [ease='Linear'] - The ease to use for the Zoom. Can be any of the Phaser Easing constants or a custom function.
-     * @param {boolean} [force=false] - Force the shake effect to start immediately, even if already running.
+     * @param {boolean} [force=false] - Force the zoom effect to start immediately, even if already running.
      * @param {CameraZoomCallback} [callback] - This callback will be invoked every frame for the duration of the effect.
      * It is sent three arguments: A reference to the camera, a progress amount between 0 and 1 indicating how complete the effect is,
      * and the current camera zoom value.


### PR DESCRIPTION
This PR

* Updates the Documentation

Describe the changes below:
Fixes the Documentation on Zoom.js. The zoom effect wrongly refers to the shake effect in the force parameter documentation.
